### PR TITLE
Example of how serializer is broken.

### DIFF
--- a/src/test/scala/io/circe/yaml/parser/ParserTests.scala
+++ b/src/test/scala/io/circe/yaml/parser/ParserTests.scala
@@ -2,6 +2,7 @@ package io.circe.yaml.parser
 
 import java.io.{BufferedReader, File, InputStreamReader}
 import org.scalatest.{FlatSpec, FreeSpec}
+import io.circe.yaml.printer._
 
 class ParserTests extends FreeSpec {
 
@@ -21,6 +22,8 @@ class ParserTests extends FreeSpec {
           new InputStreamReader(getClass.getClassLoader.getResourceAsStream(s"test-yamls/$yamlFile"))
         )
         assert(parsedJson == parsedYaml)
+        val printedYaml = parsedYaml.map(_.asYaml)
+        assert(printedYaml.isRight)
       }
     }
   }


### PR DESCRIPTION
@jeremyrsmith I'm running into an issue with the serializer. This is an example showing how the tests fail with the following exception:

```
[info] ParserTests:
[info] yaml test files
[info] - custom-tag.yml *** FAILED ***
[info]   org.yaml.snakeyaml.serializer.SerializerException: serializer is not opened
[info]   at org.yaml.snakeyaml.serializer.Serializer.serialize(Serializer.java:102)
[info]   at io.circe.yaml.printer.Printer.apply(Printer.scala:47)
[info]   at io.circe.yaml.printer.package$AsYamlSyntax$.asYaml$extension0(package.scala:10)
```